### PR TITLE
Implement streaming response support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,20 +37,29 @@ uv run python benchmark.py  # Terminal 2: Run benchmarks
 
 ### Rust Core (`src/`)
 - `lib.rs`: Main `RClient` class with sync request handling via single-threaded Tokio runtime (`LazyLock<Runtime>` with `new_current_thread()`)
-- `response.rs`: `Response` object with `CaseInsensitiveHeaderMap` for HTTP/2 compliant header handling
+  - `request()` method: Buffers entire response body
+  - `_stream()` method: Returns `StreamingResponse` without buffering body
+- `response.rs`: Response objects with `CaseInsensitiveHeaderMap` for HTTP/2 compliant header handling
+  - `Response`: Standard response with buffered `content`
+  - `StreamingResponse`: Holds `Arc<Mutex<Option<reqwest::Response>>>` for chunk iteration
+  - `TextIterator`: Iterator for decoding chunks as text
+  - `LineIterator`: Iterator for line-by-line reading with internal buffer
 - `traits.rs`: Conversion traits between Python/Rust types (IndexMap ↔ HeaderMap)
 - `utils.rs`: CA certificate loading, encoding detection
 
 ### Python Wrapper (`httpr/`)
 - `__init__.py`: `Client` (sync) and `AsyncClient` classes with context manager support
+  - `stream()` context manager wraps `_stream()` and handles cleanup
+  - Both `Client` and `AsyncClient` support streaming
 - `AsyncClient` uses `asyncio.run_in_executor()` to wrap sync Rust calls - NOT native async
-- `httpr.pyi`: Type stubs for IDE support
+- `httpr.pyi`: Type stubs for IDE support including `StreamingResponse`, `TextIterator`, `LineIterator`
 
 ### Key Design Decisions
 1. **Single Tokio Runtime**: All async Rust operations run on one thread
 2. **Async is Sync**: `AsyncClient` runs sync Rust code in thread executor
 3. **Zero Python Dependencies**: All functionality in Rust
 4. **Case-Insensitive Headers**: Custom struct maintains original casing while allowing case-insensitive lookups (HTTP/2 requirement)
+5. **Streaming**: `StreamingResponse` holds reqwest response and provides chunk iteration without buffering entire body
 
 ## Critical Implementation Details
 
@@ -79,6 +88,20 @@ uv run python benchmark.py  # Terminal 2: Run benchmarks
 ### Proxy
 - Set via `proxy` param or `HTTPR_PROXY` env var
 - Changing `client.proxy` rebuilds entire reqwest client (expensive)
+
+### Streaming Responses
+- `_stream()` method returns `StreamingResponse` without calling `.bytes()` on reqwest response
+- `StreamingResponse` holds `Arc<Mutex<Option<reqwest::Response>>>` to allow chunk reading across Python GIL boundaries
+- Chunk iteration uses `RUNTIME.block_on()` with `py.allow_threads()` to read each chunk
+- State tracking via `Arc<Mutex<bool>>` for `closed` and `consumed` flags
+- Three iteration modes:
+  - `iter_bytes()`: Direct chunk iteration (returns `Iterator[bytes]`)
+  - `iter_text()`: Returns `TextIterator` that decodes chunks using response encoding
+  - `iter_lines()`: Returns `LineIterator` with internal buffer for line-by-line reading
+- `read()` method consumes remaining response body and marks as consumed
+- `close()` method sets closed flag and drops the response
+- Python wrapper uses `@contextmanager` to ensure `close()` is called on exit
+- AsyncClient streaming: Context manager is async, but iteration is sync (same as sync Client)
 
 ## What NOT to Do
 

--- a/docs/api/async-client.md
+++ b/docs/api/async-client.md
@@ -14,6 +14,7 @@ The asynchronous HTTP client for use with asyncio.
         - post
         - put
         - patch
+        - stream
         - aclose
       show_root_heading: true
       show_root_full_path: false

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -14,6 +14,7 @@ The synchronous HTTP client with connection pooling.
         - post
         - put
         - patch
+        - stream
         - close
       show_root_heading: true
       show_root_full_path: false

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -252,3 +252,259 @@ print(data["slideshow"]["title"])
 
 !!! note
     `json()` is a method, not a property. Call it with parentheses.
+
+---
+
+## StreamingResponse
+
+For streaming large responses without buffering the entire response in memory, use the `Client.stream()` method which returns a `StreamingResponse`.
+
+```python
+import httpr
+
+with httpr.Client() as client:
+    with client.stream("GET", "https://httpbin.org/stream-bytes/1000") as response:
+        for chunk in response.iter_bytes():
+            process(chunk)
+```
+
+### Properties
+
+#### status_code
+
+```python
+@property
+def status_code(self) -> int
+```
+
+HTTP status code (e.g., 200, 404, 500).
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/get") as response:
+    print(response.status_code)  # 200
+```
+
+---
+
+#### headers
+
+```python
+@property
+def headers(self) -> CaseInsensitiveHeaderMap
+```
+
+Response headers as a case-insensitive dict-like object.
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/get") as response:
+    content_type = response.headers["content-type"]
+```
+
+---
+
+#### cookies
+
+```python
+@property
+def cookies(self) -> dict[str, str]
+```
+
+Cookies set by the server via `Set-Cookie` headers.
+
+---
+
+#### url
+
+```python
+@property
+def url(self) -> str
+```
+
+Final URL after following any redirects.
+
+---
+
+#### is_closed
+
+```python
+@property
+def is_closed(self) -> bool
+```
+
+Whether the stream has been closed.
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/get") as response:
+    print(response.is_closed)  # False
+print(response.is_closed)  # True (after context manager exits)
+```
+
+---
+
+#### is_consumed
+
+```python
+@property
+def is_consumed(self) -> bool
+```
+
+Whether the stream has been fully consumed.
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/get") as response:
+    print(response.is_consumed)  # False
+    _ = list(response)  # Consume the stream
+    print(response.is_consumed)  # True
+```
+
+---
+
+### Methods
+
+#### iter_bytes
+
+```python
+def iter_bytes(self) -> Iterator[bytes]
+```
+
+Iterate over the response body as bytes chunks.
+
+**Returns:** Iterator yielding bytes chunks
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/stream-bytes/1000") as response:
+    for chunk in response.iter_bytes():
+        print(f"Received {len(chunk)} bytes")
+```
+
+---
+
+#### iter_text
+
+```python
+def iter_text(self) -> TextIterator
+```
+
+Iterate over the response body as text chunks, decoded using the response encoding.
+
+**Returns:** TextIterator yielding string chunks
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/html") as response:
+    for text in response.iter_text():
+        print(text, end="")
+```
+
+---
+
+#### iter_lines
+
+```python
+def iter_lines(self) -> LineIterator
+```
+
+Iterate over the response body line by line.
+
+**Returns:** LineIterator yielding string lines
+
+Useful for Server-Sent Events (SSE) and line-based protocols.
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/stream/10") as response:
+    for line in response.iter_lines():
+        print(line.strip())
+```
+
+---
+
+#### read
+
+```python
+def read(self) -> bytes
+```
+
+Read the entire remaining response body into memory.
+
+**Returns:** Response body as bytes
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/get") as response:
+    if response.status_code == 200:
+        content = response.read()
+```
+
+---
+
+#### close
+
+```python
+def close(self) -> None
+```
+
+Close the stream and release resources.
+
+**Note:** When using the context manager, `close()` is called automatically.
+
+**Example:**
+```python
+with client.stream("GET", "https://httpbin.org/get") as response:
+    # Process headers
+    if response.status_code != 200:
+        response.close()  # Close early without reading body
+        return
+    # Otherwise read body
+    content = response.read()
+```
+
+---
+
+### Direct Iteration
+
+`StreamingResponse` supports direct iteration, which is equivalent to calling `iter_bytes()`:
+
+```python
+with client.stream("GET", "https://httpbin.org/stream-bytes/1000") as response:
+    for chunk in response:  # Same as response.iter_bytes()
+        process(chunk)
+```
+
+---
+
+### Important Notes
+
+- **Always use as context manager**: Ensures proper cleanup of resources
+- **Headers available immediately**: Status code, headers, cookies, and URL are accessible before reading the body
+- **Body only read on demand**: The response body is only fetched when you iterate or call `read()`
+- **Cannot re-read**: Once consumed, the stream cannot be read again
+- **Supported for all methods**: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+
+---
+
+### Exception Handling
+
+The streaming response raises specific exceptions:
+
+- `StreamClosed`: Raised when attempting to read from a closed stream
+- `StreamConsumed`: Raised when attempting to re-read a consumed stream
+
+**Example:**
+```python
+import httpr
+
+with client.stream("GET", "https://httpbin.org/get") as response:
+    content = response.read()
+
+    # This will raise StreamConsumed
+    try:
+        more = response.read()
+    except httpr.StreamConsumed:
+        print("Stream already consumed")
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,9 +130,17 @@ print(response.cookies)      # Response cookies
 
 ---
 
+## Features
+
+-   :material-water:{ .lg .middle } **Streaming**
+
+    ---
+
+    Stream large responses efficiently without buffering entire
+    response in memory. Iterate bytes, text, or lines.
+
 ## Not Yet Implemented
 
-- **Streaming**: Request/response streaming is not yet supported
 - **Fine-grained error handling**: Detailed error types are in development
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -243,6 +243,33 @@ print(response.text_plain)
 print(response.text_rich)
 ```
 
+### Streaming Responses
+
+For large responses, stream the data to avoid loading everything into memory:
+
+```python
+import httpr
+
+with httpr.Client() as client:
+    # Stream bytes
+    with client.stream("GET", "https://httpbin.org/stream-bytes/10000") as response:
+        for chunk in response.iter_bytes():
+            process(chunk)  # Process each chunk as it arrives
+
+    # Stream text
+    with client.stream("GET", "https://httpbin.org/html") as response:
+        for text in response.iter_text():
+            print(text, end="")
+
+    # Stream lines (great for Server-Sent Events)
+    with client.stream("GET", "https://httpbin.org/stream/10") as response:
+        for line in response.iter_lines():
+            print(line.strip())
+```
+
+!!! tip
+    Headers, status code, and cookies are available immediately, before reading the body.
+
 ## Timeouts
 
 Set a timeout in seconds to limit how long to wait for a response:

--- a/httpr/httpr.pyi
+++ b/httpr/httpr.pyi
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Generator, Iterator
 from typing import Any, Literal, TypedDict
 
 if sys.version_info <= (3, 11):
@@ -50,6 +51,88 @@ class Response:
     @property
     def text_rich(self) -> str: ...
 
+class TextIterator:
+    """Iterator for text chunks from a streaming response."""
+    def __iter__(self) -> TextIterator: ...
+    def __next__(self) -> str: ...
+
+class LineIterator:
+    """Iterator for lines from a streaming response."""
+    def __iter__(self) -> LineIterator: ...
+    def __next__(self) -> str: ...
+
+class StreamingResponse:
+    """
+    A streaming HTTP response that allows iterating over chunks of data.
+
+    This class provides methods to iterate over the response body in chunks
+    without buffering the entire response in memory.
+    """
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        """Response cookies."""
+        ...
+    @property
+    def headers(self) -> dict[str, str]:
+        """Response headers."""
+        ...
+    @property
+    def status_code(self) -> int:
+        """HTTP status code."""
+        ...
+    @property
+    def url(self) -> str:
+        """Final URL after any redirects."""
+        ...
+    @property
+    def is_closed(self) -> bool:
+        """Whether the stream has been closed."""
+        ...
+    @property
+    def is_consumed(self) -> bool:
+        """Whether the stream has been fully consumed."""
+        ...
+    def __iter__(self) -> Iterator[bytes]:
+        """Iterate over the response body as bytes chunks."""
+        ...
+    def __next__(self) -> bytes:
+        """Get the next chunk of bytes."""
+        ...
+    def iter_bytes(self) -> Iterator[bytes]:
+        """
+        Iterate over the response body as bytes chunks.
+
+        Yields chunks of bytes as they are received from the server.
+        """
+        ...
+    def iter_text(self) -> TextIterator:
+        """
+        Iterate over the response body as text chunks.
+
+        Decodes each chunk using the response's encoding.
+        """
+        ...
+    def iter_lines(self) -> LineIterator:
+        """
+        Iterate over the response body line by line.
+
+        Yields complete lines including newline characters.
+        """
+        ...
+    def read(self) -> bytes:
+        """
+        Read the entire remaining response body into memory.
+
+        This consumes the stream.
+        """
+        ...
+    def close(self) -> None:
+        """
+        Close the streaming response and release resources.
+        """
+        ...
+
 class RClient:
     def __init__(
         self,
@@ -83,6 +166,7 @@ class RClient:
     @proxy.setter
     def proxy(self, proxy: str) -> None: ...
     def request(self, method: HttpMethod, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
+    def _stream(self, method: HttpMethod, url: str, **kwargs: Unpack[RequestParams]) -> StreamingResponse: ...
     def get(self, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
     def head(self, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
     def options(self, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
@@ -90,6 +174,16 @@ class RClient:
     def post(self, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
     def put(self, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
     def patch(self, url: str, **kwargs: Unpack[RequestParams]) -> Response: ...
+    def stream(
+        self, method: HttpMethod, url: str, **kwargs: Unpack[RequestParams]
+    ) -> Generator[StreamingResponse, None, None]:
+        """
+        Make a streaming HTTP request.
+
+        Returns a context manager that yields a StreamingResponse for iterating
+        over the response body in chunks.
+        """
+        ...
 
 def request(method: HttpMethod, url: str, **kwargs: Unpack[ClientRequestParams]) -> Response: ...
 def get(url: str, **kwargs: Unpack[ClientRequestParams]) -> Response: ...

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,264 @@
+"""Tests for streaming response functionality."""
+
+import pytest
+import httpr  # type: ignore
+
+
+class TestStreamingClient:
+    """Test streaming functionality with sync Client."""
+
+    def test_stream_iter_bytes(self, base_url_ssl, ca_bundle):
+        """Test iterating over response as bytes chunks."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        # Use /get endpoint which returns JSON
+        with client.stream("GET", f"{base_url_ssl}/get") as response:
+            assert response.status_code == 200
+            chunks = list(response.iter_bytes())
+            total_bytes = b"".join(chunks)
+            assert len(total_bytes) > 0
+            assert b"headers" in total_bytes  # JSON response contains 'headers'
+
+    def test_stream_direct_iteration(self, base_url_ssl, ca_bundle):
+        """Test iterating directly over StreamingResponse."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/html") as response:
+            assert response.status_code == 200
+            chunks = list(response)
+            total_bytes = b"".join(chunks)
+            assert len(total_bytes) > 0
+            assert b"html" in total_bytes.lower()
+
+    def test_stream_iter_text(self, base_url_ssl, ca_bundle):
+        """Test iterating over response as text chunks."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        # Use /html endpoint which returns HTML text
+        with client.stream("GET", f"{base_url_ssl}/html") as response:
+            assert response.status_code == 200
+            chunks = list(response.iter_text())
+            full_text = "".join(chunks)
+            # Should contain HTML data
+            assert len(full_text) > 0
+            assert "html" in full_text.lower()
+
+    def test_stream_iter_lines(self, base_url_ssl, ca_bundle):
+        """Test iterating over response line by line."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        # /robots.txt returns multiple lines
+        with client.stream("GET", f"{base_url_ssl}/robots.txt") as response:
+            assert response.status_code == 200
+            lines = list(response.iter_lines())
+            # Should have multiple lines
+            assert len(lines) >= 1
+
+    def test_stream_read_all(self, base_url_ssl, ca_bundle):
+        """Test reading entire response body at once."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/get") as response:
+            assert response.status_code == 200
+            content = response.read()
+            assert len(content) > 0
+            assert b"headers" in content
+
+    def test_stream_conditional_read(self, base_url_ssl, ca_bundle):
+        """Test conditional reading based on status code."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/status/200") as response:
+            if response.status_code == 200:
+                # Just close without reading - should work fine
+                pass
+            else:
+                content = response.read()
+
+    def test_stream_headers_available(self, base_url_ssl, ca_bundle):
+        """Test that headers are available before iteration."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/response-headers?X-Test=test-value") as response:
+            # Headers should be available immediately
+            assert "content-type" in response.headers or "Content-Type" in response.headers
+            assert response.status_code == 200
+
+    def test_stream_cookies_available(self, base_url_ssl, ca_bundle):
+        """Test that cookies are available before iteration."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/cookies/set/test_cookie/test_value") as response:
+            # Note: cookies might be in response.cookies depending on redirect behavior
+            assert response.status_code == 200
+
+    def test_stream_url_available(self, base_url_ssl, ca_bundle):
+        """Test that URL is available."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/get") as response:
+            assert response.url.endswith("/get")
+            assert response.status_code == 200
+
+    def test_stream_is_closed(self, base_url_ssl, ca_bundle):
+        """Test is_closed property."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/get") as response:
+            assert response.is_closed is False
+        
+        # After context manager exits, should be closed
+        assert response.is_closed is True
+
+    def test_stream_is_consumed(self, base_url_ssl, ca_bundle):
+        """Test is_consumed property."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/get") as response:
+            assert response.is_consumed is False
+            # Consume the stream
+            _ = list(response)
+            assert response.is_consumed is True
+
+    def test_stream_close_stops_iteration(self, base_url_ssl, ca_bundle):
+        """Test that closing the stream stops further iteration."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/html") as response:
+            # Read one chunk
+            chunk = next(iter(response))
+            assert len(chunk) > 0
+            # Close explicitly
+            response.close()
+            # Should raise StreamClosed on next iteration
+            with pytest.raises(httpr.StreamClosed):
+                next(iter(response))
+
+    def test_stream_consumed_error(self, base_url_ssl, ca_bundle):
+        """Test that iterating consumed stream raises StreamConsumed."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/get") as response:
+            # Consume the stream
+            _ = list(response)
+            # Try to iterate again - should raise StreamConsumed
+            with pytest.raises(httpr.StreamConsumed):
+                next(iter(response))
+
+    def test_stream_with_params(self, base_url_ssl, ca_bundle):
+        """Test streaming with query parameters."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream("GET", f"{base_url_ssl}/get", params={"key": "value"}) as response:
+            assert response.status_code == 200
+            content = response.read()
+            assert b"key" in content
+
+    def test_stream_with_headers(self, base_url_ssl, ca_bundle):
+        """Test streaming with custom headers."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream(
+            "GET", 
+            f"{base_url_ssl}/headers",
+            headers={"X-Custom-Header": "custom-value"}
+        ) as response:
+            assert response.status_code == 200
+            content = response.read()
+            assert b"X-Custom-Header" in content
+
+    def test_stream_post_with_json(self, base_url_ssl, ca_bundle):
+        """Test streaming POST request with JSON body."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with client.stream(
+            "POST",
+            f"{base_url_ssl}/post",
+            json={"test": "data"}
+        ) as response:
+            assert response.status_code == 200
+            content = response.read()
+            assert b"test" in content
+
+    def test_stream_invalid_method(self, base_url_ssl, ca_bundle):
+        """Test that invalid HTTP method raises ValueError."""
+        client = httpr.Client(ca_cert_file=ca_bundle)
+        
+        with pytest.raises(ValueError, match="Unsupported HTTP method"):
+            with client.stream("INVALID", f"{base_url_ssl}/get") as response:
+                pass
+
+
+@pytest.mark.asyncio
+class TestStreamingAsyncClient:
+    """Test streaming functionality with async AsyncClient."""
+
+    async def test_async_stream_iter_bytes(self, base_url_ssl, ca_bundle):
+        """Test async iterating over response as bytes chunks."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream("GET", f"{base_url_ssl}/get") as response:
+                assert response.status_code == 200
+                chunks = list(response.iter_bytes())
+                total_bytes = b"".join(chunks)
+                assert len(total_bytes) > 0
+
+    async def test_async_stream_direct_iteration(self, base_url_ssl, ca_bundle):
+        """Test async direct iteration over StreamingResponse."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream("GET", f"{base_url_ssl}/html") as response:
+                assert response.status_code == 200
+                chunks = list(response)
+                total_bytes = b"".join(chunks)
+                assert len(total_bytes) > 0
+
+    async def test_async_stream_iter_text(self, base_url_ssl, ca_bundle):
+        """Test async iterating over response as text chunks."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream("GET", f"{base_url_ssl}/html") as response:
+                assert response.status_code == 200
+                chunks = list(response.iter_text())
+                full_text = "".join(chunks)
+                assert len(full_text) > 0
+
+    async def test_async_stream_iter_lines(self, base_url_ssl, ca_bundle):
+        """Test async iterating over response line by line."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream("GET", f"{base_url_ssl}/robots.txt") as response:
+                assert response.status_code == 200
+                lines = list(response.iter_lines())
+                assert len(lines) >= 1
+
+    async def test_async_stream_read_all(self, base_url_ssl, ca_bundle):
+        """Test async reading entire response body at once."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream("GET", f"{base_url_ssl}/get") as response:
+                assert response.status_code == 200
+                content = response.read()
+                assert len(content) > 0
+
+    async def test_async_stream_headers_available(self, base_url_ssl, ca_bundle):
+        """Test that headers are available before iteration in async."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream("GET", f"{base_url_ssl}/get") as response:
+                assert response.status_code == 200
+                # Use keys() instead of len() since CaseInsensitiveHeaderMap doesn't have __len__
+                assert len(response.headers.keys()) > 0
+
+    async def test_async_stream_with_params(self, base_url_ssl, ca_bundle):
+        """Test async streaming with query parameters."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            async with client.stream(
+                "GET", 
+                f"{base_url_ssl}/get", 
+                params={"key": "value"}
+            ) as response:
+                assert response.status_code == 200
+                content = response.read()
+                assert b"key" in content
+
+    async def test_async_stream_invalid_method(self, base_url_ssl, ca_bundle):
+        """Test that invalid HTTP method raises ValueError in async."""
+        async with httpr.AsyncClient(ca_cert_file=ca_bundle) as client:
+            with pytest.raises(ValueError, match="Unsupported HTTP method"):
+                async with client.stream("INVALID", f"{base_url_ssl}/get") as response:
+                    pass


### PR DESCRIPTION
Add streaming support for efficient handling of large HTTP responses without buffering entire response in memory.

Features:
- StreamingResponse class with three iteration modes: iter_bytes(), iter_text(), iter_lines()
- Context manager support for both Client.stream() and AsyncClient.stream()
- State tracking with is_closed and is_consumed properties
- Proper resource cleanup and exception handling (StreamClosed, StreamConsumed)
- Headers, status code, and cookies available before reading body

Implementation:
- Rust: StreamingResponse holds Arc<Mutex<Option<reqwest::Response>>> for chunk iteration
- Python: Context managers ensure proper cleanup via close() method
- AsyncClient: Async context manager with sync iteration (matches design pattern)
- Comprehensive test coverage in tests/test_streaming.py

Documentation:
- Updated README.md with streaming examples
- Added StreamingResponse API reference in docs/api/response.md
- Added streaming tutorial in docs/tutorial/response-handling.md
- Updated docs/index.md to reflect streaming is now implemented
- Added streaming examples to docs/quickstart.md
- Updated CLAUDE.md with implementation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)