### PR TITLE
Add free-threaded Python support (PEP 703)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,7 +645,7 @@ impl RClient {
     }
 }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn httpr(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     pyo3_log::init();
 


### PR DESCRIPTION
## Summary

Declare the httpr module as GIL-free by adding `gil_used = false` to the `#[pymodule]` attribute. This enables native support for free-threaded Python (3.13+) without triggering a RuntimeWarning or requiring the `PYTHON_GIL=0` environment variable.

## Changes

- Added `gil_used = false` to the `#[pymodule]` macro in `src/lib.rs`

## Thread Safety Justification

The module is safe to declare as free-threaded because:

- **RClient**: Uses `Arc<Mutex<...>>` for both `client` and `headers` fields
- **RUNTIME**: Uses `LazyLock<Runtime>` for thread-safe initialization  
- **StreamingResponse**: Uses `Arc<Mutex<...>>` for all mutable state
- **Exception types**: Stateless and thread-safe by default

## Background

Per [PyO3 documentation](https://pyo3.rs/v0.23.4/free-threading.html), setting `gil_used = false` on the module declaration:

1. Sets the `Py_MOD_GIL` slot to `Py_MOD_GIL_NOT_USED`
2. Tells the Python interpreter the extension is thread-safe
3. Avoids re-enabling the GIL at runtime when importing the module

## Testing

- All existing tests pass
- Module imports and functions correctly