### PR TITLE
ci: auto-release dev versions on push to main

### DIFF
--- a/.github/workflows/set_version.py
+++ b/.github/workflows/set_version.py
@@ -76,8 +76,10 @@ def update_version(version):
 
         print(f"pyproject.toml version updated to: {version}")
 
-        # Also update Cargo.toml
-        if not update_cargo_version(project_root, version):
+        # Also update Cargo.toml with base version (Cargo doesn't support .dev suffixes)
+        # Extract base version by stripping any .devN suffix
+        cargo_version = re.sub(r'\.dev\d+$', '', version)
+        if not update_cargo_version(project_root, cargo_version):
             print("Error: failed to update Cargo.toml")
             sys.exit(1)
 


### PR DESCRIPTION
## Summary
Enables automatic PyPI releases on every push to main branch, with proper versioning.

## Changes

### Version Strategy
- **Main branch pushes**: Publish dev versions (e.g., `0.2.3.dev154`) using GitHub run number
- **Tag pushes**: Publish stable versions (e.g., `0.2.3`)
- **Manual dispatch**: Can also trigger releases

### Key Implementation Details
- pyproject.toml gets full version including `.devN` suffix
- Cargo.toml gets base semver version (Rust doesn't support PEP 440 `.dev` suffixes)
- Uses `tomlkit` to preserve file formatting when updating versions
- Reusable composite action for version setting (supports Unix + Windows)
- Test job gates releases on main branch pushes

### CI Workflow Updates
- Tests run on PRs and main branch pushes
- Build jobs wait for test success before proceeding
- Release job publishes to PyPI on main pushes (dev) and tags (stable)

### Version Bump
- Updated base version from 0.1.0 to 0.2.3 (synced with PyPI)

## Testing
- Verified `set_version.py` works correctly for both dev and stable versions
- Confirmed file formatting is preserved (tomlkit vs toml library)