### PR TITLE
fix: use relative paths for llms.txt links in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -149,8 +149,8 @@ print(response.cookies)      # Response cookies
 
 This documentation is available in LLM-optimized formats:
 
-- **[llms.txt](/llms.txt)** - Documentation index for LLMs
-- **[llms-full.txt](/llms-full.txt)** - Complete documentation in a single file
+- **[llms.txt](llms.txt)** - Documentation index for LLMs
+- **[llms-full.txt](llms-full.txt)** - Complete documentation in a single file
 
 ---
 


### PR DESCRIPTION
## Problem

The llms.txt links in the docs index page were using absolute paths (`/llms.txt` and `/llms-full.txt`) which resolved to the domain root (`thomasht86.github.io/llms.txt`) instead of the site path (`thomasht86.github.io/httpr/llms.txt`), causing 404 errors.

## Solution

Changed to relative paths (`llms.txt` and `llms-full.txt`) which correctly resolve to the site root where the files are actually located.

## Testing

- The files are correctly generated at `site/llms.txt` and `site/llms-full.txt` during build
- Relative paths will resolve correctly: `https://thomasht86.github.io/httpr/llms.txt`