### PR TITLE
fix: use absolute URLs for llms.txt links to pass strict mode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -149,8 +149,8 @@ print(response.cookies)      # Response cookies
 
 This documentation is available in LLM-optimized formats:
 
-- **[llms.txt](llms.txt)** - Documentation index for LLMs
-- **[llms-full.txt](llms-full.txt)** - Complete documentation in a single file
+- **[llms.txt](https://thomasht86.github.io/httpr/llms.txt)** - Documentation index for LLMs
+- **[llms-full.txt](https://thomasht86.github.io/httpr/llms-full.txt)** - Complete documentation in a single file
 
 ---
 


### PR DESCRIPTION
MkDocs in strict mode validates relative links against known documentation files. Since llms.txt and llms-full.txt are generated by the llmstxt plugin (not regular docs), relative links caused warnings that failed the build.

Using full absolute URLs bypasses link validation while ensuring the links work correctly on the deployed site.