### PR TITLE
ci: skip pytest on armv7 to avoid slow QEMU emulation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,22 +135,8 @@ jobs:
           set -e
           uv sync --extra dev --find-links dist --reinstall
           uv run pytest
-      - name: pytest
-        if: ${{ matrix.platform.target == 'armv7' }}
-        uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: ${{ matrix.platform.target }}
-          distro: ubuntu22.04
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip python3-dev build-essential libffi-dev libssl-dev pkg-config curl
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-          run: |
-            set -e
-            export PATH="$HOME/.local/bin:$PATH"
-            uv sync --extra dev --find-links dist --reinstall
-            uv run pytest
+      # Skip pytest on armv7 - QEMU emulation is 20x+ slower than native.
+      # Tests already run on x86_64 and aarch64 which provides sufficient coverage.
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}


### PR DESCRIPTION
QEMU emulation for armv7 tests takes 20x+ longer than native execution. Since tests already run on x86_64 and aarch64 (native ARM), we have sufficient architecture coverage.

This change:
- Removes the slow armv7 pytest step that used `uraimo/run-on-arch-action`
- Keeps armv7 wheel building for distribution
- Adds a comment explaining the rationale