### PR TITLE
ci: run tests on tag pushes to enable release from GitHub Releases UI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Rust clippy
         run: cargo clippy -- -D warnings
 
-  # Fast test job - runs on PRs and main branch pushes with Python version matrix
+  # Fast test job - runs on PRs, main branch pushes, and tag pushes with Python version matrix
   test:
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Provides precompiled wheels for the following platforms:
 | Job | PRs | Push to main | Tags (Release) | Manual |
 |-----|:---:|:------------:|:--------------:|:------:|
 | `lint` | ✓ | | | |
-| `test` (Python 3.10-3.14) | ✓ | ✓ | | |
+| `test` (Python 3.10-3.14) | ✓ | ✓ | ✓ | |
 | `docs` (build) | ✓ | | | |
 | `linux`, `musllinux`, `windows`, `macos`, `sdist` | | | ✓ | ✓ |
 | `release` (PyPI publish) | | | ✓ | ✓ |
@@ -350,7 +350,7 @@ Provides precompiled wheels for the following platforms:
 
 - **PRs**: Run lint, tests across Python 3.10-3.14 matrix, and verify docs build
 - **Push to main**: Run tests only
-- **Tags**: Build wheels, publish stable release to PyPI, run benchmarks
+- **Tags**: Run tests, build wheels, publish stable release to PyPI, run benchmarks
 - **Manual**: Full multi-platform wheel builds with release and benchmarks
 
 ## Acknowledgements


### PR DESCRIPTION
Previously, the test job only ran on PRs and pushes to main. When creating a release from GitHub's Releases UI (which pushes a tag), tests were skipped.

This change:
- Adds tag pushes to the test job condition so tests run before building wheels for a release
- Updates README CI table to reflect that tests now run on tags

Now when you create a release from GitHub's Releases section:
1. Tag push triggers the workflow
2. Tests run across Python 3.10-3.14
3. Build jobs run (wheels for all platforms)
4. Release job publishes to PyPI
5. Benchmark runs