### PR TITLE
fix: grant write permissions to Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write      # Required to push to branches
+      pull-requests: write # Required to create PRs and post comments
+      issues: write        # Required to post comments on issues
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read        # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Update Claude Code workflow permissions from `read` to `write` for `contents`, `pull-requests`, and `issues`
- Enables Claude to push to branches and create PRs when triggered via `@claude` mentions
- By default, only users with write permissions (maintainers) can trigger Claude

## Test plan
- [ ] Verify workflow runs successfully when triggered
- [ ] Test that Claude can push commits and create PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)