### PR TITLE
fix: add workflows permission to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,7 @@ jobs:
       issues: write        # Required to post comments on issues
       id-token: write
       actions: read        # Required for Claude to read CI results on PRs
+      workflows: write     # Required to modify workflow files
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `workflows: write` permission to Claude Code workflow
- Enables Claude to modify workflow files (e.g., `.github/workflows/CI.yml`)
- Fixes the blocker in #39 where Claude couldn't push changes that included workflow file modifications

## Context
In issue #39, Claude completed all the Python 3.9 support changes but was blocked from pushing because the changes included an update to `CI.yml` to add Python 3.9 to the test matrix. GitHub requires explicit `workflows` permission to modify files in `.github/workflows/`.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger Claude on #39 to complete the Python 3.9 support PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)