### PR TITLE
fix: disable sccache for musllinux builds on tag pushes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,7 +225,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: true
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
## Summary

- Fix musllinux CI build failure caused by sccache not being available inside Docker container
- The first "Build wheels" step had `sccache: true` unconditionally, which sets `RUSTC_WRAPPER=sccache` on the host
- When the build runs inside the musllinux Docker container, sccache is not available, causing "No such file or directory" errors
- This change aligns both musllinux build steps to use the same conditional `sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Create a test tag to verify release builds work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)