### PR TITLE
fix: run e2e tests on tag pushes to prevent release job skipping

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,10 +64,10 @@ jobs:
           uv run task dev
           uv run task test:unit
 
-  # E2E tests with httpbun Docker container - runs on PRs and main branch
+  # E2E tests with httpbun Docker container - runs on PRs, main branch, and tag pushes
   e2e:
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

- Fix release job being skipped on tag pushes
- The root cause: e2e tests weren't configured to run on tag pushes, and since e2e is in the dependency chain (build jobs need `[test, e2e]`), the skip status propagated to the release job
- This change adds `startsWith(github.ref, 'refs/tags/')` to the e2e job condition

## Changes

**Before:** e2e only runs on PRs and main branch pushes
```yaml
if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
```

**After:** e2e also runs on tag pushes (releases)
```yaml
if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
```

## Benefits

1. Releases are validated with e2e tests before publishing to PyPI
2. Release job no longer gets incorrectly skipped
3. More robust release pipeline

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merging, create a test tag to verify full release pipeline works

🤖 Generated with [Claude Code](https://claude.com/claude-code)