### PR TITLE
refactor: migrate from serde_cbor to ciborium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +213,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "deranged"
@@ -387,9 +420,14 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -470,10 +508,11 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpr"
-version = "0.2.3"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "ciborium",
  "encoding_rs",
  "foldhash",
  "html2text",
@@ -483,7 +522,6 @@ dependencies = [
  "pythonize",
  "reqwest",
  "rustls-pemfile",
- "serde_cbor",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -1373,16 +1411,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ html2text = "0.13.6"
 bytes = "1.10.0"
 pythonize = "0.27.0"
 serde_json = "1.0.138"
-serde_cbor = "0.11.2"
+ciborium = "0.2"
 webpki-root-certs = "0.26.8"
 rustls-pemfile = "2.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,8 @@ impl RClient {
 
                     if use_cbor {
                         // Serialize as CBOR
-                        let cbor_bytes = serde_cbor::to_vec(&json_data)
+                        let mut cbor_bytes = Vec::new();
+                        ciborium::into_writer(&json_data, &mut cbor_bytes)
                             .map_err(|e| anyhow!("Failed to serialize CBOR: {}", e))?;
                         request_builder = request_builder
                             .header(CONTENT_TYPE, "application/cbor")
@@ -637,7 +638,8 @@ impl RClient {
 
                     if use_cbor {
                         // Serialize as CBOR
-                        let cbor_bytes = serde_cbor::to_vec(&json_data)
+                        let mut cbor_bytes = Vec::new();
+                        ciborium::into_writer(&json_data, &mut cbor_bytes)
                             .map_err(|e| anyhow!("Failed to serialize CBOR: {}", e))?;
                         request_builder = request_builder
                             .header(CONTENT_TYPE, "application/cbor")

--- a/src/response.rs
+++ b/src/response.rs
@@ -192,9 +192,8 @@ impl Response {
 
         if content_type.to_lowercase().contains("application/cbor") {
             // Deserialize as CBOR
-            let cbor_value: serde_json::Value =
-                serde_cbor::from_slice(self.content.as_bytes(py))
-                    .map_err(|e| anyhow!("Failed to deserialize CBOR: {}", e))?;
+            let cbor_value: serde_json::Value = ciborium::from_reader(self.content.as_bytes(py))
+                .map_err(|e| anyhow!("Failed to deserialize CBOR: {}", e))?;
             let result = pythonize(py, &cbor_value)
                 .map_err(|e| anyhow!("Failed to convert CBOR to Python object: {}", e))?
                 .unbind();
@@ -210,7 +209,7 @@ impl Response {
     }
 
     fn cbor(&mut self, py: Python) -> Result<Py<PyAny>> {
-        let cbor_value: serde_json::Value = serde_cbor::from_slice(self.content.as_bytes(py))
+        let cbor_value: serde_json::Value = ciborium::from_reader(self.content.as_bytes(py))
             .map_err(|e| anyhow!("Failed to deserialize CBOR: {}", e))?;
         let result = pythonize(py, &cbor_value)
             .map_err(|e| anyhow!("Failed to convert CBOR to Python object: {}", e))?


### PR DESCRIPTION
## Summary

- Migrate from deprecated `serde_cbor` crate to `ciborium` (the recommended replacement)
- Replace `serde_cbor::to_vec` with `ciborium::into_writer` for serialization
- Replace `serde_cbor::from_slice` with `ciborium::from_reader` for deserialization

## Background

The `serde_cbor` crate is no longer actively maintained. The maintainers recommend using `ciborium` instead.

## Test plan

- [x] Build passes (`maturin develop`)
- [x] Rust lints pass (`cargo fmt` + `cargo clippy`)
- [x] All 102 unit tests pass (including CBOR-specific tests)

🤖 Generated with [Claude Code](https://claude.ai/code)