### PR TITLE
refactor: migrate CBOR dependency from ciborium to serde_cbor_2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,33 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "compression-codecs"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +485,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ciborium",
  "encoding_rs",
  "foldhash",
  "html2text",
@@ -522,6 +494,7 @@ dependencies = [
  "pythonize",
  "reqwest",
  "rustls-pemfile",
+ "serde_cbor_2",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -1411,6 +1384,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ html2text = "0.13.6"
 bytes = "1.10.0"
 pythonize = "0.27.0"
 serde_json = "1.0.138"
-ciborium = "0.2"
+serde_cbor_2 = "0.13"
 webpki-root-certs = "0.26.8"
 rustls-pemfile = "2.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl RClient {
                     if use_cbor {
                         // Serialize as CBOR
                         let mut cbor_bytes = Vec::new();
-                        ciborium::into_writer(&json_data, &mut cbor_bytes)
+                        serde_cbor_2::to_writer(&mut cbor_bytes, &json_data)
                             .map_err(|e| anyhow!("Failed to serialize CBOR: {}", e))?;
                         request_builder = request_builder
                             .header(CONTENT_TYPE, "application/cbor")
@@ -639,7 +639,7 @@ impl RClient {
                     if use_cbor {
                         // Serialize as CBOR
                         let mut cbor_bytes = Vec::new();
-                        ciborium::into_writer(&json_data, &mut cbor_bytes)
+                        serde_cbor_2::to_writer(&mut cbor_bytes, &json_data)
                             .map_err(|e| anyhow!("Failed to serialize CBOR: {}", e))?;
                         request_builder = request_builder
                             .header(CONTENT_TYPE, "application/cbor")

--- a/src/response.rs
+++ b/src/response.rs
@@ -192,8 +192,9 @@ impl Response {
 
         if content_type.to_lowercase().contains("application/cbor") {
             // Deserialize as CBOR
-            let cbor_value: serde_json::Value = ciborium::from_reader(self.content.as_bytes(py))
-                .map_err(|e| anyhow!("Failed to deserialize CBOR: {}", e))?;
+            let cbor_value: serde_json::Value =
+                serde_cbor_2::from_reader(self.content.as_bytes(py))
+                    .map_err(|e| anyhow!("Failed to deserialize CBOR: {}", e))?;
             let result = pythonize(py, &cbor_value)
                 .map_err(|e| anyhow!("Failed to convert CBOR to Python object: {}", e))?
                 .unbind();
@@ -209,7 +210,7 @@ impl Response {
     }
 
     fn cbor(&mut self, py: Python) -> Result<Py<PyAny>> {
-        let cbor_value: serde_json::Value = ciborium::from_reader(self.content.as_bytes(py))
+        let cbor_value: serde_json::Value = serde_cbor_2::from_reader(self.content.as_bytes(py))
             .map_err(|e| anyhow!("Failed to deserialize CBOR: {}", e))?;
         let result = pythonize(py, &cbor_value)
             .map_err(|e| anyhow!("Failed to convert CBOR to Python object: {}", e))?


### PR DESCRIPTION
## Summary
- Replace `ciborium` crate with `serde_cbor_2` for CBOR serialization/deserialization
- Update API calls: `into_writer` → `to_writer` (with swapped argument order), `from_reader` remains the same
- All existing CBOR tests pass

## Test plan
- [x] Build with `uv run maturin develop`
- [x] Run CBOR tests: `uv run pytest tests/unit/test_cbor.py -v`
- [x] Run full unit test suite: `task test:unit`
- [x] Run Rust linters: `task lint:rust`

🤖 Generated with [Claude Code](https://claude.ai/code)