### PR TITLE
fix: run benchmark workflow after mkdocs to preserve data

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,12 @@
 name: Benchmark
 
 on:
-  push:
+  workflow_run:
+    workflows: ["mkdocs"]
+    types:
+      - completed
     branches:
       - main
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - ".github/workflows/mkdocs.yml"
   workflow_dispatch:
 
 permissions:
@@ -18,6 +17,7 @@ jobs:
   benchmark:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Change benchmark workflow trigger from `push` to `workflow_run` (triggered after mkdocs completes)
- Add condition to only run if mkdocs succeeded
- Fixes race condition where mkdocs `--force` push would wipe benchmark data from gh-pages

## Root Cause
Both workflows triggered on push to main. MkDocs uses `gh-deploy --force` which wipes the entire gh-pages branch, deleting any benchmark data that was previously added.

## Test plan
- [ ] Merge this PR
- [ ] Verify mkdocs workflow runs on merge
- [ ] Verify benchmark workflow triggers after mkdocs completes
- [ ] Check https://thomasht86.github.io/httpr/dev/bench/ shows accumulated data points

🤖 Generated with [Claude Code](https://claude.ai/code)