### PR TITLE
fix: expose constructor headers via Client.headers property

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl RClient {
         let mut client_builder = reqwest::Client::builder();
 
         // Headers || Cookies
-        if headers.is_some() || cookies.is_some() {
+        let headers_headermap = if headers.is_some() || cookies.is_some() {
             let headers = headers.unwrap_or_else(|| IndexMap::with_hasher(RandomState::default()));
             let mut headers_headermap = headers.to_headermap();
             if let Some(cookies) = cookies {
@@ -156,7 +156,10 @@ impl RClient {
                         .map_err(|e| map_anyhow_error(anyhow::Error::new(e)))?,
                 );
             }
-            client_builder = client_builder.default_headers(headers_headermap);
+            client_builder = client_builder.default_headers(headers_headermap.clone());
+            headers_headermap
+        } else {
+            reqwest::header::HeaderMap::new()
         };
 
         // Cookie_store
@@ -231,7 +234,7 @@ impl RClient {
         let client = Arc::new(Mutex::new(
             client_builder.build().map_err(map_reqwest_error)?,
         ));
-        let headers = Arc::new(Mutex::new(reqwest::header::HeaderMap::new()));
+        let headers = Arc::new(Mutex::new(headers_headermap));
 
         Ok(RClient {
             client,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -278,6 +278,48 @@ def test_client_post_files(test_files):
     assert json_data["files"] == {"file1": "aaa111", "file2": "bbb222"}
 
 
+def test_constructor_headers_accessible():
+    """Test that headers passed to constructor are accessible via the headers property."""
+    client = httpr.Client(headers={"X-Custom": "value", "User-Agent": "test-agent"})
+    assert client.headers == {"x-custom": "value", "user-agent": "test-agent"}
+    client.close()
+
+
+def test_constructor_headers_with_cookies():
+    """Test that cookies are excluded from headers getter when passed to constructor."""
+    client = httpr.Client(
+        headers={"X-Custom": "value"},
+        cookies={"session": "abc123"},
+    )
+    # Cookies should not appear in headers getter
+    assert client.headers == {"x-custom": "value"}
+    # But cookies should be accessible via cookies getter
+    assert client.cookies == {"session": "abc123"}
+    client.close()
+
+
+def test_constructor_cookies_only():
+    """Test that cookies-only constructor doesn't expose Cookie header."""
+    client = httpr.Client(cookies={"session": "abc123"})
+    # Headers should be empty (no Cookie header exposed)
+    assert client.headers == {}
+    # Cookies should be accessible
+    assert client.cookies == {"session": "abc123"}
+    client.close()
+
+
+def test_setter_overwrites_constructor_headers():
+    """Test that setting headers overwrites constructor headers."""
+    client = httpr.Client(headers={"X-Original": "original"})
+    assert client.headers == {"x-original": "original"}
+    # Overwrite with new headers
+    client.headers = {"X-New": "new"}
+    assert client.headers == {"x-new": "new"}
+    # Original header should be gone
+    assert "x-original" not in client.headers
+    client.close()
+
+
 def test_graceful_invalid_header_handling(base_url_ssl, ca_bundle):
     """Test that invalid header values are handled gracefully without crashing."""
     client = httpr.Client(ca_cert_file=ca_bundle)


### PR DESCRIPTION
## Summary
- Headers passed to `Client()` constructor were not accessible via `.headers` property (always returned empty dict)
- Root cause: constructor headers were used for `default_headers()` but `self.headers` was initialized empty
- Fix: Store the constructor headers in `self.headers` instead of creating empty HeaderMap

## Test plan
- [x] Added `test_constructor_headers_accessible` - verifies headers passed to constructor are accessible
- [x] Added `test_constructor_headers_with_cookies` - verifies cookies are excluded from headers getter
- [x] Added `test_constructor_cookies_only` - verifies cookies-only constructor doesn't expose Cookie header
- [x] Added `test_setter_overwrites_constructor_headers` - verifies setter correctly overwrites constructor headers
- [x] All 112 unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)