### PR TITLE
feat: make Client.headers case-insensitive

### DIFF
--- a/httpr/__init__.py
+++ b/httpr/__init__.py
@@ -42,6 +42,20 @@ else:
 
 from .httpr import CaseInsensitiveHeaderMap, RClient, Response, StreamingResponse
 
+
+class CaseInsensitiveDict(dict):
+    """A dict subclass that provides case-insensitive key access."""
+
+    def __getitem__(self, key):
+        return super().__getitem__(key.lower())
+
+    def __contains__(self, key):
+        return super().__contains__(key.lower())
+
+    def get(self, key, default=None):
+        return super().get(key.lower(), default)
+
+
 if TYPE_CHECKING:
     from .httpr import ClientRequestParams, HttpMethod, RequestParams
 else:
@@ -206,6 +220,15 @@ class Client(RClient):
             ```
         """
         del self
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """Headers configured for this client (case-insensitive access)."""
+        return CaseInsensitiveDict(super().headers)
+
+    @headers.setter
+    def headers(self, value: dict[str, str] | None) -> None:
+        RClient.headers.__set__(self, value)  # type: ignore[attr-defined]
 
     def request(
         self,

--- a/httpr/__init__.py
+++ b/httpr/__init__.py
@@ -49,11 +49,23 @@ class CaseInsensitiveDict(dict):
     def __getitem__(self, key):
         return super().__getitem__(key.lower())
 
+    def __setitem__(self, key, value):
+        super().__setitem__(key.lower(), value)
+
+    def __delitem__(self, key):
+        super().__delitem__(key.lower())
+
     def __contains__(self, key):
         return super().__contains__(key.lower())
 
     def get(self, key, default=None):
         return super().get(key.lower(), default)
+
+    def pop(self, key, *args):
+        return super().pop(key.lower(), *args)
+
+    def setdefault(self, key, default=None):
+        return super().setdefault(key.lower(), default)
 
 
 if TYPE_CHECKING:

--- a/httpr/__init__.py
+++ b/httpr/__init__.py
@@ -43,29 +43,37 @@ else:
 from .httpr import CaseInsensitiveHeaderMap, RClient, Response, StreamingResponse
 
 
-class CaseInsensitiveDict(dict):
+class CaseInsensitiveDict(dict[str, str]):
     """A dict subclass that provides case-insensitive key access."""
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> str:
         return super().__getitem__(key.lower())
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: str) -> None:
         super().__setitem__(key.lower(), value)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         super().__delitem__(key.lower())
 
-    def __contains__(self, key):
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
         return super().__contains__(key.lower())
 
-    def get(self, key, default=None):
+    def get(self, key: str, default: str | None = None) -> str | None:  # type: ignore[override]
         return super().get(key.lower(), default)
 
-    def pop(self, key, *args):
+    def pop(self, key: str, *args: str) -> str:  # type: ignore[override]
         return super().pop(key.lower(), *args)
 
-    def setdefault(self, key, default=None):
-        return super().setdefault(key.lower(), default)
+    def setdefault(self, key: str, default: str | None = None) -> str | None:  # type: ignore[override]
+        return super().setdefault(key.lower(), default)  # type: ignore[arg-type]
+
+    def update(self, other: dict[str, str] | None = None, **kwargs: str) -> None:  # type: ignore[override]
+        if other is not None:
+            super().update({k.lower(): v for k, v in other.items()})
+        if kwargs:
+            super().update({k.lower(): v for k, v in kwargs.items()})
 
 
 if TYPE_CHECKING:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -76,6 +76,7 @@ def test_client_setters(base_url_ssl, ca_bundle):
     assert response.status_code == 200
     assert client.auth == ("user", "password")
     assert client.headers == {"x-test": "TesT"}  # Headers are lowercased (necessary for HTTP/2)
+    assert client.headers["X-Test"] == "TesT"  # but still accessible case-insensitively
     assert client.cookies == {"ccc": "ddd", "cccc": "dddd"}
     assert client.params == {"x": "aaa", "y": "bbb"}
     assert client.timeout == 20.0
@@ -317,6 +318,29 @@ def test_setter_overwrites_constructor_headers():
     assert client.headers == {"x-new": "new"}
     # Original header should be gone
     assert "x-original" not in client.headers
+    client.close()
+
+
+def test_client_headers_case_insensitive():
+    """Test that client.headers supports case-insensitive access."""
+    client = httpr.Client(headers={"X-Custom": "value", "Content-Type": "application/json"})
+
+    # Case-insensitive access should work
+    assert client.headers["x-custom"] == "value"
+    assert client.headers["X-Custom"] == "value"
+    assert client.headers["X-CUSTOM"] == "value"
+
+    # Contains check should be case-insensitive
+    assert "x-custom" in client.headers
+    assert "X-Custom" in client.headers
+
+    # get() should be case-insensitive
+    assert client.headers.get("X-Custom") == "value"
+    assert client.headers.get("x-custom") == "value"
+
+    # Dict equality should still work (keys are lowercased)
+    assert client.headers == {"x-custom": "value", "content-type": "application/json"}
+
     client.close()
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -341,6 +341,20 @@ def test_client_headers_case_insensitive():
     # Dict equality should still work (keys are lowercased)
     assert client.headers == {"x-custom": "value", "content-type": "application/json"}
 
+    # Test mutating methods on the returned dict (doesn't affect client, but should work)
+    headers = client.headers
+    headers["X-New"] = "new-value"
+    assert headers["x-new"] == "new-value"
+
+    del headers["X-New"]
+    assert "x-new" not in headers
+
+    headers["X-Pop"] = "pop-value"
+    assert headers.pop("X-POP") == "pop-value"
+
+    assert headers.setdefault("X-Default", "default") == "default"
+    assert headers["x-default"] == "default"
+
     client.close()
 
 


### PR DESCRIPTION
## Summary
- Add `CaseInsensitiveDict` wrapper class that allows case-insensitive key access
- Override `Client.headers` property to return headers wrapped in `CaseInsensitiveDict`
- `client.headers["X-Custom"]`, `client.headers["x-custom"]`, and `client.headers["X-CUSTOM"]` all work now

## Test plan
- [x] Added `test_client_headers_case_insensitive` test covering `__getitem__`, `__contains__`, and `get()` methods
- [x] All existing tests pass
- [x] mypy and ruff checks pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)