### PR TITLE
Disable automatic SBOMs for reproducible wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,14 @@ benchmark = [ "matplotlib", "pandas", "starlette", "uvicorn", "requests", "httpx
 [tool.maturin]
 features = [ "pyo3/extension-module",]
 
+[tool.maturin.sbom]
+# cargo-cyclonedx currently embeds build-path- and run-specific fields into the
+# generated SBOM, which makes otherwise identical wheels differ across hosts and
+# build directories. Re-enable once the upstream toolchain can emit
+# reproducible wheel-embedded SBOMs.
+rust = false
+auditwheel = false
+
 [tool.ruff]
 line-length = 120
 exclude = [ ".github",]


### PR DESCRIPTION
## Goals of this PR
Make `pip wheel` output reproducible across build directories and hosts.

## Related context
`maturin`'s default wheel-embedded SBOM currently comes from `cargo-cyclonedx`.
That SBOM includes build-path-specific `bom-ref` values plus run-specific `timestamp` and `serialNumber` fields, which makes otherwise identical wheels differ byte-for-byte.

## Updates made
Disable `maturin`'s automatic Rust and auditwheel SBOM generation in `pyproject.toml`.
Add an inline comment describing why this is disabled and when it should be safe to re-enable.

## Notes for reviewers
I verified this by building the wheel twice from two different source directories with `python -m pip wheel --no-deps ...`.
Before this change, the only differing wheel members were `dist-info/sboms/httpr.cyclonedx.json` and `RECORD`.
After this change, the two wheel SHA256 values match exactly.

## Testing
`python3 -m pip wheel --no-deps -w /tmp/httpr-wheel-a /tmp/httpr-repro-a`
`python3 -m pip wheel --no-deps -w /tmp/httpr-wheel-b /tmp/httpr-repro-b`
Compared the resulting wheel SHA256 values and per-file contents.