### PR TITLE
fix(tls): apply client identity even when verify=False

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,22 +204,23 @@ impl RClient {
                     client_builder = client_builder.add_root_certificate(cert);
                 }
             }
-            // Load client pem identity if provided
-            // Either from file path (client_pem) or direct data (client_pem_data)
-            let client_identity_pem = if let Some(pem_data) = &client_pem_data {
-                Some(pem_data.clone())
-            } else if let Some(pem_path) = &client_pem {
-                Some(fs::read(pem_path).map_err(|e| map_anyhow_error(anyhow::Error::new(e)))?)
-            } else {
-                None
-            };
-
-            if let Some(pem_bytes) = client_identity_pem {
-                let identity = Identity::from_pem(&pem_bytes).map_err(map_reqwest_error)?;
-                client_builder = client_builder.identity(identity);
-            }
         } else {
             client_builder = client_builder.danger_accept_invalid_certs(true);
+        }
+
+        // Client mTLS identity must be applied regardless of `verify`: disabling
+        // server verification doesn't imply disabling client authentication.
+        let client_identity_pem = if let Some(pem_data) = &client_pem_data {
+            Some(pem_data.clone())
+        } else if let Some(pem_path) = &client_pem {
+            Some(fs::read(pem_path).map_err(|e| map_anyhow_error(anyhow::Error::new(e)))?)
+        } else {
+            None
+        };
+
+        if let Some(pem_bytes) = client_identity_pem {
+            let identity = Identity::from_pem(&pem_bytes).map_err(map_reqwest_error)?;
+            client_builder = client_builder.identity(identity);
         }
 
         // Https_only

--- a/tests/unit/test_ssl.py
+++ b/tests/unit/test_ssl.py
@@ -184,6 +184,38 @@ class TestClientSSL(unittest.TestCase):
                 ca_cert_file=self.client_ca_path,
             )
 
+    def test_client_cert_sent_when_verify_disabled(self):
+        """Regression for issue #65: client cert must still be presented when verify=False.
+
+        Disabling server verification should not disable client authentication.
+        """
+        # client_pem (file path) + verify=False
+        with Client(client_pem=self.client_cert_path, verify=False) as client:
+            response = client.get(f"https://localhost:{self.server_port}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.text, "OK")
+
+        # client_pem_data (bytes) + verify=False
+        with open(self.client_cert_path, "rb") as f:
+            cert_data = f.read()
+        with Client(client_pem_data=cert_data, verify=False) as client:
+            response = client.get(f"https://localhost:{self.server_port}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.text, "OK")
+
+    def test_async_client_cert_sent_when_verify_disabled(self):
+        """Regression for issue #65 on the AsyncClient Python wrapper."""
+        with open(self.client_cert_path, "rb") as f:
+            cert_data = f.read()
+
+        async def make_request():
+            async with AsyncClient(client_pem_data=cert_data, verify=False) as client:
+                return await client.get(f"https://localhost:{self.server_port}")
+
+        response = asyncio.run(make_request())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "OK")
+
     def test_async_client_pem_and_data_are_mutually_exclusive(self):
         """AsyncClient should also enforce mutual exclusivity."""
         with open(self.client_cert_path, "rb") as f:


### PR DESCRIPTION
Client mTLS identity (client_pem / client_pem_data) was nested inside the
`verify=true` branch of the TLS builder, so disabling server verification
silently disabled client authentication too. Move identity application
outside the branch so it is applied unconditionally.

Fixes #65