### PR TITLE
fix ca bundle silent fallback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,10 +199,8 @@ impl RClient {
         // Verify
         if verify.unwrap_or(true) {
             client_builder = client_builder.tls_built_in_root_certs(true);
-            if let Ok(certs) = load_ca_certs() {
-                for cert in certs {
-                    client_builder = client_builder.add_root_certificate(cert);
-                }
+            for cert in load_ca_certs().map_err(map_anyhow_error)? {
+                client_builder = client_builder.add_root_certificate(cert);
             }
             // Load client pem identity if provided
             // Either from file path (client_pem) or direct data (client_pem_data)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,16 +29,25 @@ fn read_pem_certificates(path: &str) -> Result<Vec<Certificate>> {
     let cert_bytes = fs::read(path).context("Failed to read certificate file")?;
     let mut certificates = vec![];
     let mut cursor = std::io::Cursor::new(cert_bytes);
-    while let Ok(Some(cert)) = rustls_pemfile::read_one(&mut cursor) {
-        match cert {
-            rustls_pemfile::Item::X509Certificate(cert) => {
+    loop {
+        match rustls_pemfile::read_one(&mut cursor)
+            .context("Failed to parse PEM data from certificate file")?
+        {
+            None => break,
+            Some(rustls_pemfile::Item::X509Certificate(cert)) => {
                 let certificate = Certificate::from_der(&cert)?;
                 certificates.push(certificate);
             }
-            _ => {
+            Some(_) => {
                 tracing::warn!("Skipping non-certificate item");
             }
         }
+    }
+    if certificates.is_empty() {
+        anyhow::bail!(
+            "No X.509 certificates found in {}: refusing to silently fall back to built-in roots",
+            path
+        );
     }
     Ok(certificates)
 }
@@ -129,15 +138,51 @@ Q29uc3VsdGF0aW9uczEiMCAGCSqGSIb3DQEJARYTcGVyc29uYWwtZW1haWwuY29t
 
         // Clean up
         fs::remove_file(ca_cert_path).unwrap();
+        env::remove_var("HTTPR_CA_BUNDLE");
     }
 
     #[test]
     fn test_load_ca_certs_without_env_var() {
+        env::remove_var("HTTPR_CA_BUNDLE");
         // Call the function
         let result = load_ca_certs();
 
         // Check the result
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_load_ca_certs_malformed_bundle_errors() {
+        // A readable file whose contents are not a valid PEM bundle must error
+        // rather than silently returning an empty cert list (which would cause
+        // a silent fall-back to built-in roots).
+        let path = Path::new("test_ca_malformed.pem");
+        fs::write(path, b"this is not a PEM certificate at all").unwrap();
+        env::set_var("HTTPR_CA_BUNDLE", path);
+
+        let result = load_ca_certs();
+
+        fs::remove_file(path).unwrap();
+        env::remove_var("HTTPR_CA_BUNDLE");
+
+        assert!(result.is_err(), "expected error for malformed PEM, got {:?}", result);
+    }
+
+    #[test]
+    fn test_load_ca_certs_no_certs_errors() {
+        // A syntactically-valid PEM file containing only non-certificate items
+        // (e.g. an unrelated private key, or just comments) yields zero certs
+        // and must error rather than silently fall back to built-in roots.
+        let path = Path::new("test_ca_no_certs.pem");
+        fs::write(path, b"# only a comment, no certs here\n").unwrap();
+        env::set_var("HTTPR_CA_BUNDLE", path);
+
+        let result = load_ca_certs();
+
+        fs::remove_file(path).unwrap();
+        env::remove_var("HTTPR_CA_BUNDLE");
+
+        assert!(result.is_err(), "expected error for cert-less bundle, got {:?}", result);
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -165,7 +165,11 @@ Q29uc3VsdGF0aW9uczEiMCAGCSqGSIb3DQEJARYTcGVyc29uYWwtZW1haWwuY29t
         fs::remove_file(path).unwrap();
         env::remove_var("HTTPR_CA_BUNDLE");
 
-        assert!(result.is_err(), "expected error for malformed PEM, got {:?}", result);
+        assert!(
+            result.is_err(),
+            "expected error for malformed PEM, got {:?}",
+            result
+        );
     }
 
     #[test]
@@ -182,7 +186,11 @@ Q29uc3VsdGF0aW9uczEiMCAGCSqGSIb3DQEJARYTcGVyc29uYWwtZW1haWwuY29t
         fs::remove_file(path).unwrap();
         env::remove_var("HTTPR_CA_BUNDLE");
 
-        assert!(result.is_err(), "expected error for cert-less bundle, got {:?}", result);
+        assert!(
+            result.is_err(),
+            "expected error for cert-less bundle, got {:?}",
+            result
+        );
     }
 }
 

--- a/tests/unit/test_ssl.py
+++ b/tests/unit/test_ssl.py
@@ -132,10 +132,45 @@ class TestClientSSL(unittest.TestCase):
                 client.get(f"https://localhost:{self.server_port}")
 
     def test_invalid_ca_cert_file(self):
-        """Using an invalid CA certificate file should cause a handshake failure."""
-        with Client(client_pem=self.client_cert_path, ca_cert_file="nonexistent_ca.pem") as client:
-            with self.assertRaises(Exception):
-                client.get(f"https://localhost:{self.server_port}")
+        """A non-existent ca_cert_file must fail loudly at client construction.
+
+        Previously load_ca_certs() errors were swallowed at the call site, so a
+        bad bundle silently fell back to the built-in Mozilla roots — the client
+        would then trust servers the user never intended to trust.
+        """
+        with self.assertRaises(httpr.RequestError):
+            Client(client_pem=self.client_cert_path, ca_cert_file="nonexistent_ca.pem")
+
+    def test_malformed_ca_cert_file(self):
+        """A readable but non-PEM ca_cert_file must also fail at construction.
+
+        The parse-error path was previously swallowed inside read_pem_certificates,
+        so a corrupt bundle silently produced zero certs and the client fell back
+        to built-in roots.
+        """
+        with tempfile.NamedTemporaryFile(
+            suffix=".pem", delete=False, mode="wb"
+        ) as f:
+            f.write(b"this is not a valid PEM bundle")
+            bad_path = f.name
+        try:
+            with self.assertRaises(httpr.RequestError):
+                Client(client_pem=self.client_cert_path, ca_cert_file=bad_path)
+        finally:
+            os.unlink(bad_path)
+
+    def test_empty_ca_cert_file(self):
+        """A PEM file with no X.509 certs (e.g. only comments) must also fail."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".pem", delete=False, mode="wb"
+        ) as f:
+            f.write(b"# bundle with no certificates\n")
+            empty_path = f.name
+        try:
+            with self.assertRaises(httpr.RequestError):
+                Client(client_pem=self.client_cert_path, ca_cert_file=empty_path)
+        finally:
+            os.unlink(empty_path)
 
     def test_verify_disabled_with_valid_client_cert(self):
         """


### PR DESCRIPTION
if a ca bundle is specified we should not silently fall back to default "any signed cert" behaviour