### PR TITLE
fix(ci): drop free-threaded 3.13t wheel build (abi3 incompatible)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,7 +176,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t -i python3.14t
+          args: --release --out dist -i python3.14t
           sccache: true
           manylinux: auto
       - name: Upload wheels
@@ -231,7 +231,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t -i python3.14t
+          args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -287,7 +287,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t -i python3.14t
+          args: --release --out dist -i python3.14t
           sccache: true
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -333,7 +333,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t -i python3.14t
+          args: --release --out dist -i python3.14t
           sccache: true
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The v0.5.0 release ([run 29639143829](https://github.com/thomasht86/httpr/actions/runs/29639143829)) failed on every wheel-build job (linux, musllinux, windows, macos) at the **Build free-threaded wheels** step:

```
💥 maturin failed
  Caused by: Free-threaded Python interpreter is only supported on 3.14 and later.
```

## Root cause

The free-threaded step built for `-i python3.13t -i python3.14t`, but the crate produces a stable-ABI wheel (`abi3-py39` in `Cargo.toml`). Free-threaded (`t`) interpreters have **no stable ABI before CPython 3.14**, so an abi3 build cannot target `python3.13t` and maturin hard-errors.

Only the wheel jobs (tag-push gated) exercise this step, so v0.5.0 was the first release to hit it.

## Fix

Build free-threaded wheels for `python3.14t` only, across all four platform jobs. Users on 3.13t fall back to the sdist.

## Notes

- Dropping Python 3.9 does **not** fix this — abi3 stays enabled regardless of the floor, so 3.13t would still error. Tracked separately.
- Producing 3.13t free-threaded wheels would require a separate non-abi3 build; out of scope for unblocking the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)